### PR TITLE
From address img having hardcoded height of 44px to a max-height of 42px...

### DIFF
--- a/css/display.css
+++ b/css/display.css
@@ -117,7 +117,7 @@ body#outbox #core ul.messages .notice:before,
 
 
 address img {
-    height: 44px;
+    max-height: 42px;
     margin-left: 10px;
     margin-top: -4px;
     max-width: none;


### PR DESCRIPTION
... so it won't overflow the header.
